### PR TITLE
add php stubs for IDE support

### DIFF
--- a/stubs/GraphQL/Error/ParseError.php
+++ b/stubs/GraphQL/Error/ParseError.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace GraphQL\Error;
+
+class ParseError extends \Exception {}

--- a/stubs/GraphQL/Parser.php
+++ b/stubs/GraphQL/Parser.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace GraphQL;
+
+class Parser
+{
+    /**
+     * @param string $input
+     *
+     * @return array
+     */
+    public function parse(string $input): array {
+        return [];
+    }
+}


### PR DESCRIPTION
For IDE's to pickup the classes you're generating with C you need to write stub files.

Here you go for the current interface. Doesn't seem like there's an automatic way to generate these :(

Side note: I was looking into the involved in adding proper AST classes instead of returning as array. It's fairly involved :( this is a script that does it for Ruby. But then on top of that we would need to make something that creates stub files for those automatically. I don't know if this is worth it, but it sure would be nice. Might just do a conversion from array to AST in PHP for now.